### PR TITLE
Explicitly skip ID 0 if indexing in DynamoDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ cli:
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-findingaid-create-dynamodb-tables cmd/wof-findingaid-create-dynamodb-tables/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-findingaid-create-dynamodb-import cmd/wof-findingaid-create-dynamodb-import/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-findingaid-resolverd cmd/wof-findingaid-resolverd/main.go
+	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-findingaid-resolve cmd/wof-findingaid-resolve/main.go
 
 
 lambda:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ package main
 
 import (
 	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/whosonfirst/go-whosonfirst-iterate-git/v2"
+	_ "github.com/whosonfirst/go-whosonfirst-iterate-git/v3"
 )
 
 import (
@@ -130,6 +130,7 @@ go build -mod vendor -ldflags="-s -w" -o bin/wof-findingaid-csv2docstore cmd/wof
 go build -mod vendor -ldflags="-s -w" -o bin/wof-findingaid-create-dynamodb-tables cmd/wof-findingaid-create-dynamodb-tables/main.go
 go build -mod vendor -ldflags="-s -w" -o bin/wof-findingaid-create-dynamodb-import cmd/wof-findingaid-create-dynamodb-import/main.go
 go build -mod vendor -ldflags="-s -w" -o bin/wof-findingaid-resolverd cmd/wof-findingaid-resolverd/main.go
+go build -mod vendor -ldflags="-s -w" -o bin/wof-findingaid-resolve cmd/wof-findingaid-resolve/main.go
 ```
 
 ### wof-findingaid-csv2sql
@@ -191,6 +192,36 @@ $> ./bin/wof-findingaid-populate \
 
 This would create separate findingaids for `sfomuseum-data-flights-2019-01`, `sfomuseum-data-flights-2019-02` and so on.
 
+### wof-findingaid-resolve
+
+Command line tool for resolving one or more Who's On First style identifiers to their corresponding repository name using a go-whosonfirst-findingaid/v2/resolver.Resolver instance.
+
+```
+$> ./bin/wof-findingaid-resolve -h
+  -id value
+    	One or more IDs to resolve
+  -resolver-uri string
+    	A registered whosonfirst/go-whosonfirst-findingaid/v2/resolver.Resolver URI.
+  -verbose
+    	Enable verbose (debug) logging.
+```
+
+For example:
+
+```
+$> ./bin/wof-findingaid-resolve \
+	-resolver-uri 'awsdynamodb://findingaid?partition_key=id&region=us-east-1&credentials=session' \
+	-id 1511947225 \
+	-id 404529563 \
+	-verbose
+	
+2025/09/25 10:55:53 DEBUG Verbose logging enabled
+2025/09/25 10:55:58 DEBUG Get repo id=1511947225
+1511947225	sfomuseum-data-collection
+2025/09/25 10:55:58 DEBUG Get repo id=404529563
+2025/09/25 10:55:58 Failed to run resolve tool, Failed to derive repo for 404529563, Not found
+```
+
 ### wof-findingaid-resolverd
 
 resolverd provides an HTTP server endpoint for resolving Who's On First URIs to their corresponding repository name using a go-whosonfirst-findingaid/v2/resolver.Resolver instance.
@@ -208,6 +239,7 @@ $> ./bin/wof-findingaid-resolverd -resolver-uri 'awsdynamodb:///findingaid?regio
 $> curl http://localhost:8080/1678780019
 sfomuseum-data-flights-2018
 ```
+
 
 ### sources
 

--- a/app/resolve/flags.go
+++ b/app/resolve/flags.go
@@ -15,7 +15,7 @@ func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("resolve")
 
-	fs.StringVar(&resolver_uri, "resolver-uri", "", "...")
+	fs.StringVar(&resolver_uri, "resolver-uri", "", "A registered whosonfirst/go-whosonfirst-findingaid/v2/resolver.Resolver URI.")
 	fs.Var(&ids, "id", "One or more IDs to resolve")
 	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 	return fs

--- a/app/resolve/flags.go
+++ b/app/resolve/flags.go
@@ -1,0 +1,22 @@
+package resolve
+
+import (
+	"flag"
+
+	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/sfomuseum/go-flags/multi"
+)
+
+var resolver_uri string
+var ids multi.MultiInt64
+var verbose bool
+
+func DefaultFlagSet() *flag.FlagSet {
+
+	fs := flagset.NewFlagSet("resolve")
+
+	fs.StringVar(&resolver_uri, "resolver-uri", "", "...")
+	fs.Var(&ids, "id", "One or more IDs to resolve")
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
+	return fs
+}

--- a/app/resolve/options.go
+++ b/app/resolve/options.go
@@ -1,0 +1,26 @@
+package resolve
+
+import (
+	"flag"
+
+	"github.com/sfomuseum/go-flags/flagset"
+)
+
+type RunOptions struct {
+	ResolverURI string
+	Ids         []int64
+	Verbose     bool
+}
+
+func RunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
+
+	flagset.Parse(fs)
+
+	opts := &RunOptions{
+		ResolverURI: resolver_uri,
+		Ids:         ids,
+		Verbose:     verbose,
+	}
+
+	return opts, nil
+}

--- a/app/resolve/resolve.go
+++ b/app/resolve/resolve.go
@@ -1,0 +1,54 @@
+package resolve
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+
+	"github.com/whosonfirst/go-whosonfirst-findingaid/v2/resolver"
+)
+
+func Run(ctx context.Context) error {
+	fs := DefaultFlagSet()
+	return RunWithFlagSet(ctx, fs)
+}
+
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
+
+	opts, err := RunOptionsFromFlagSet(fs)
+
+	if err != nil {
+		return fmt.Errorf("Failed to derive run options, %w", err)
+	}
+
+	return RunWithOptions(ctx, opts)
+}
+
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
+
+	if opts.Verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
+
+	r, err := resolver.NewResolver(ctx, opts.ResolverURI)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create new resolver, %w", err)
+	}
+
+	for _, id := range opts.Ids {
+
+		slog.Debug("Get repo", "id", id)
+		repo, err := r.GetRepo(ctx, id)
+
+		if err != nil {
+			return fmt.Errorf("Failed to derive repo for %d, %w", id, err)
+		}
+
+		fmt.Printf("%d\t%s\n", id, repo)
+	}
+
+	return nil
+}

--- a/cmd/wof-findingaid-resolve/main.go
+++ b/cmd/wof-findingaid-resolve/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/whosonfirst/go-whosonfirst-findingaid/v2/app/resolve"
+)
+
+func main() {
+
+	ctx := context.Background()
+	err := resolve.Run(ctx)
+
+	if err != nil {
+		log.Fatalf("Failed to run resolve tool, %v", err)
+	}
+}

--- a/cmd/wof-findingaid-resolverd/main.go
+++ b/cmd/wof-findingaid-resolverd/main.go
@@ -23,8 +23,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/aaronland/go-http/v3/server"
 	"github.com/aaronland/go-http/v3/handlers"
+	"github.com/aaronland/go-http/v3/server"
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/whosonfirst/go-whosonfirst-findingaid/v2/resolver"
 	"github.com/whosonfirst/go-whosonfirst-uri"

--- a/producer/docstore.go
+++ b/producer/docstore.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/url"
+	"strings"
 	"sync"
 
 	aa_docstore "github.com/aaronland/gocloud/docstore"
@@ -31,7 +33,7 @@ CorsParams:	*
 
 type DocstoreProducer struct {
 	Producer
-	engine     string
+	scheme     string
 	collection *gc_docstore.Collection
 	path_repo  string
 }
@@ -76,6 +78,7 @@ func NewDocstoreProducer(ctx context.Context, uri string) (Producer, error) {
 	}
 
 	p := &DocstoreProducer{
+		scheme:     u.Scheme,
 		collection: collection,
 		path_repo:  path_repo,
 	}
@@ -108,6 +111,13 @@ func (p *DocstoreProducer) PopulateWithIterator(ctx context.Context, monitor tim
 		}
 
 		if uri_args.IsAlternate {
+			continue
+		}
+
+		// Sigh...
+
+		if id == 0 && strings.Contains(p.scheme, "dynamodb") {
+			slog.Warn("Skipping ID 0 because it makes DynamoDB sad")
 			continue
 		}
 

--- a/vendor/github.com/sfomuseum/go-flags/multi/bool.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/bool.go
@@ -1,0 +1,12 @@
+package multi
+
+type MultiBool []bool
+
+func (m *MultiBool) Set(value bool) error {
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *MultiBool) Get() interface{} {
+	return *m
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/float.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/float.go
@@ -1,0 +1,47 @@
+package multi
+
+import (
+	"strconv"
+	"strings"
+)
+
+type MultiFloat64 []float64
+
+func (m *MultiFloat64) String() string {
+
+	str_values := make([]string, len(*m))
+
+	for i, v := range *m {
+		str_values[i] = strconv.FormatFloat(v, 'f', 10, 64)
+	}
+
+	return strings.Join(str_values, "\n")
+}
+
+func (m *MultiFloat64) Set(str_value string) error {
+
+	value, err := strconv.ParseFloat(str_value, 64)
+
+	if err != nil {
+		return err
+	}
+
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *MultiFloat64) Get() interface{} {
+	return *m
+}
+
+func (m *MultiFloat64) Contains(value float64) bool {
+
+	for _, test := range *m {
+
+		if test == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/int.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/int.go
@@ -1,0 +1,88 @@
+package multi
+
+import (
+	"strconv"
+	"strings"
+)
+
+type MultiInt []int
+
+func (m *MultiInt) String() string {
+
+	str_values := make([]string, len(*m))
+
+	for i, v := range *m {
+		str_values[i] = strconv.Itoa(v)
+	}
+
+	return strings.Join(str_values, "\n")
+}
+
+func (m *MultiInt) Set(str_value string) error {
+
+	value, err := strconv.Atoi(str_value)
+
+	if err != nil {
+		return err
+	}
+
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *MultiInt) Get() interface{} {
+	return *m
+}
+
+func (m *MultiInt) Contains(value int) bool {
+
+	for _, test := range *m {
+
+		if test == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+type MultiInt64 []int64
+
+func (m *MultiInt64) String() string {
+
+	str_values := make([]string, len(*m))
+
+	for i, v := range *m {
+		str_values[i] = strconv.FormatInt(v, 10)
+	}
+
+	return strings.Join(str_values, "\n")
+}
+
+func (m *MultiInt64) Set(str_value string) error {
+
+	value, err := strconv.ParseInt(str_value, 10, 64)
+
+	if err != nil {
+		return err
+	}
+
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *MultiInt64) Get() interface{} {
+	return *m
+}
+
+func (m *MultiInt64) Contains(value int64) bool {
+
+	for _, test := range *m {
+
+		if test == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/keyvalue.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/keyvalue.go
@@ -1,0 +1,91 @@
+package multi
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const SEP string = "="
+
+type KeyValueFlag interface {
+	Key() string
+	Value() interface{}
+}
+
+type KeyValueStringFlag struct {
+	KeyValueFlag
+	key   string
+	value string
+}
+
+func (e *KeyValueStringFlag) Key() string {
+	return e.key
+}
+
+func (e *KeyValueStringFlag) Value() interface{} {
+	return e.value
+}
+
+type KeyValueCSVString []*KeyValueStringFlag
+
+func (e *KeyValueCSVString) String() string {
+
+	parts := make([]string, len(*e))
+
+	for idx, k := range *e {
+		parts[idx] = fmt.Sprintf("%s=%s", k.Key(), k.Value().(string))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func (e *KeyValueCSVString) Set(value string) error {
+
+	for _, v := range strings.Split(value, ",") {
+
+		value = strings.Trim(v, " ")
+		kv := strings.Split(v, SEP)
+
+		if len(kv) != 2 {
+			return errors.New("Invalid key=value argument")
+		}
+
+		a := KeyValueStringFlag{
+			key:   kv[0],
+			value: kv[1],
+		}
+
+		*e = append(*e, &a)
+	}
+
+	return nil
+}
+
+type KeyValueString []*KeyValueStringFlag
+
+func (e *KeyValueString) String() string {
+	return fmt.Sprintf("%v", *e)
+}
+
+func (e *KeyValueString) Set(value string) error {
+
+	value = strings.Trim(value, " ")
+	kv := strings.Split(value, SEP)
+
+	if len(kv) != 2 {
+		return errors.New("Invalid key=value argument")
+	}
+
+	a := KeyValueStringFlag{
+		key:   kv[0],
+		value: kv[1],
+	}
+
+	*e = append(*e, &a)
+	return nil
+}
+
+func (e *KeyValueString) Get() interface{} {
+	return *e
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_bool.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_bool.go
@@ -1,0 +1,55 @@
+package multi
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type KeyValueBoolFlag struct {
+	key   string
+	value bool
+}
+
+func (e *KeyValueBoolFlag) Key() string {
+	return e.key
+}
+
+func (e *KeyValueBoolFlag) Value() interface{} {
+	return e.value
+}
+
+type KeyValueBool []*KeyValueBoolFlag
+
+func (e *KeyValueBool) String() string {
+	return fmt.Sprintf("%v", *e)
+}
+
+func (e *KeyValueBool) Set(value string) error {
+
+	value = strings.Trim(value, " ")
+	kv := strings.Split(value, SEP)
+
+	if len(kv) != 2 {
+		return errors.New("Invalid key=value argument")
+	}
+
+	v, err := strconv.ParseBool(kv[1])
+
+	if err != nil {
+		return err
+	}
+
+	a := KeyValueBoolFlag{
+		key:   kv[0],
+		value: v,
+	}
+
+	*e = append(*e, &a)
+	return nil
+}
+
+func (e *KeyValueBool) Get() interface{} {
+	return *e
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_float.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_float.go
@@ -1,0 +1,55 @@
+package multi
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type KeyValueFloat64Flag struct {
+	key   string
+	value float64
+}
+
+func (e *KeyValueFloat64Flag) Key() string {
+	return e.key
+}
+
+func (e *KeyValueFloat64Flag) Value() interface{} {
+	return e.value
+}
+
+type KeyValueFloat64 []*KeyValueFloat64Flag
+
+func (e *KeyValueFloat64) String() string {
+	return fmt.Sprintf("%v", *e)
+}
+
+func (e *KeyValueFloat64) Set(value string) error {
+
+	value = strings.Trim(value, " ")
+	kv := strings.Split(value, SEP)
+
+	if len(kv) != 2 {
+		return errors.New("Invalid key=value argument")
+	}
+
+	v, err := strconv.ParseFloat(kv[1], 64)
+
+	if err != nil {
+		return err
+	}
+
+	a := KeyValueFloat64Flag{
+		key:   kv[0],
+		value: v,
+	}
+
+	*e = append(*e, &a)
+	return nil
+}
+
+func (e *KeyValueFloat64) Get() interface{} {
+	return *e
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_int.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/keyvalue_int.go
@@ -1,0 +1,55 @@
+package multi
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type KeyValueInt64Flag struct {
+	key   string
+	value int64
+}
+
+func (e *KeyValueInt64Flag) Key() string {
+	return e.key
+}
+
+func (e *KeyValueInt64Flag) Value() interface{} {
+	return e.value
+}
+
+type KeyValueInt64 []*KeyValueInt64Flag
+
+func (e *KeyValueInt64) String() string {
+	return fmt.Sprintf("%v", *e)
+}
+
+func (e *KeyValueInt64) Set(value string) error {
+
+	value = strings.Trim(value, " ")
+	kv := strings.Split(value, SEP)
+
+	if len(kv) != 2 {
+		return errors.New("Invalid key=value argument")
+	}
+
+	v, err := strconv.ParseInt(kv[1], 10, 64)
+
+	if err != nil {
+		return err
+	}
+
+	a := KeyValueInt64Flag{
+		key:   kv[0],
+		value: v,
+	}
+
+	*e = append(*e, &a)
+	return nil
+}
+
+func (e *KeyValueInt64) Get() interface{} {
+	return *e
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/regexp.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/regexp.go
@@ -1,0 +1,36 @@
+package multi
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type MultiRegexp []*regexp.Regexp
+
+func (i *MultiRegexp) String() string {
+
+	patterns := make([]string, 0)
+
+	for _, re := range *i {
+		patterns = append(patterns, fmt.Sprintf("%v", re))
+	}
+
+	return strings.Join(patterns, "\n")
+}
+
+func (i *MultiRegexp) Set(value string) error {
+
+	re, err := regexp.Compile(value)
+
+	if err != nil {
+		return err
+	}
+
+	*i = append(*i, re)
+	return nil
+}
+
+func (i *MultiRegexp) Get() interface{} {
+	return *i
+}

--- a/vendor/github.com/sfomuseum/go-flags/multi/string.go
+++ b/vendor/github.com/sfomuseum/go-flags/multi/string.go
@@ -1,0 +1,63 @@
+package multi
+
+import (
+	"strings"
+)
+
+type MultiString []string
+
+func (m *MultiString) String() string {
+	return strings.Join(*m, "\n")
+}
+
+func (m *MultiString) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *MultiString) Get() interface{} {
+	return *m
+}
+
+func (m *MultiString) Contains(value string) bool {
+
+	for _, test := range *m {
+
+		if test == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+type MultiCSVString []string
+
+func (m *MultiCSVString) String() string {
+	return strings.Join(*m, "\n")
+}
+
+func (m *MultiCSVString) Set(value string) error {
+
+	for _, v := range strings.Split(value, ",") {
+		*m = append(*m, v)
+	}
+
+	return nil
+}
+
+func (m *MultiCSVString) Get() interface{} {
+	return *m
+}
+
+func (m *MultiCSVString) Contains(value string) bool {
+
+	for _, test := range *m {
+
+		if test == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -414,6 +414,7 @@ github.com/sfomuseum/go-edtf
 # github.com/sfomuseum/go-flags v0.11.0
 ## explicit; go 1.22
 github.com/sfomuseum/go-flags/flagset
+github.com/sfomuseum/go-flags/multi
 # github.com/sfomuseum/go-timings v1.4.0
 ## explicit; go 1.22
 github.com/sfomuseum/go-timings


### PR DESCRIPTION
* Explicitly skip ID 0 if indexing in DynamoDB. This is an unfortunate hack to prevent "missing document key" errors.